### PR TITLE
Improve configuration properties meta-data

### DIFF
--- a/src/main/java/com/fineuploader/UploadServerProperties.java
+++ b/src/main/java/com/fineuploader/UploadServerProperties.java
@@ -1,5 +1,8 @@
 package com.fineuploader;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -10,13 +13,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("fineuploader")
 public class UploadServerProperties {
 
-    private String baseDir = "./uploads";
+    /**
+     * Root upload directory.
+     */
+    private Path baseDir = Paths.get("./uploads");
 
-    public String getBaseDir() {
+    public Path getBaseDir() {
         return baseDir;
     }
 
-    public void setBaseDir(String baseDir) {
+    public void setBaseDir(Path baseDir) {
         this.baseDir = baseDir;
     }
 

--- a/src/main/java/com/fineuploader/io/FileSystemStorageService.java
+++ b/src/main/java/com/fineuploader/io/FileSystemStorageService.java
@@ -12,7 +12,6 @@ import java.io.*;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Created by ovaldez on 11/13/16.
@@ -26,7 +25,7 @@ public class FileSystemStorageService implements StorageService {
 
     @Autowired
     public FileSystemStorageService(UploadServerProperties props) {
-        this.basePath = Paths.get(props.getBaseDir());
+        this.basePath = props.getBaseDir();
     }
 
     @Override


### PR DESCRIPTION
This commit changes the type of the `base-dir` property to `Path` as
the standard `ConversionService` is able to handle it from a `String`
value. This has the advantage of rejecting any invalid String value
at bootstrap time rather than failing later.

Also, this commit documents the property so that the description shows
up in IDEs that support code assistance for configuration properties.